### PR TITLE
fix: Исправление для фильмов с отсутствующим возрастным рейтингом

### DIFF
--- a/Contents/Libraries/Shared/kinoplex/sources/kinopoisk.py
+++ b/Contents/Libraries/Shared/kinoplex/sources/kinopoisk.py
@@ -273,7 +273,8 @@ class KinopoiskSource(SourceBase):
             metadata['original_title'] = movie_data['nameOriginal']
 
         metadata['tagline'] = movie_data.get('slogan', '')
-        metadata['content_rating_age'] = int(movie_data.get('ratingAgeLimits').replace('age', '') or 0)
+        if movie_data.get('ratingAgeLimits'):
+            metadata['content_rating_age'] = int(movie_data.get('ratingAgeLimits').replace('age', '') or 0)
         try:
             metadata['year'] = int(movie_data.get('year', ''))
         except:


### PR DESCRIPTION
Например фильм "Was uns nicht umbringt" 
https://www.kinopoisk.ru/film/1003450/
Для него API выдает "ratingAgeLimits": null , в результате чего всё ломается и данные не грузятся в PLEX.