### PR TITLE
Fix NoneType handling in desc

### DIFF
--- a/Contents/Libraries/Shared/kinoplex/sources/kinopoisk.py
+++ b/Contents/Libraries/Shared/kinoplex/sources/kinopoisk.py
@@ -327,7 +327,7 @@ class KinopoiskSource(SourceBase):
             if self.api.Prefs['desc_rating_vote_count'] and movie_data.get('ratingImdbVoteCount'):
                 summary_add += ' (%s)' % movie_data.get('ratingImdbVoteCount')
             summary_add += '\n' if self.api.Prefs['desc_rating_newline'] else '. '
-        metadata['summary'] = summary_add + movie_data.get('description', '')
+        metadata['summary'] = summary_add + (movie_data.get('description', '') or '')
         
         metadata['main_poster'] = {
             'full': movie_data.get('posterUrl'),


### PR DESCRIPTION
Фикс ошибки и отказа загрузки остальных метаданных, если неоф. API возвращает 
`"description": null`

```
2023-10-16 02:12:03,635 (2388) :  DEBUG (utils:111) - Requesting 'https://kinopoiskapiunofficial.tech/api/v2.2/films/1436271'
Traceback (most recent call last):
  File "C:\Users\ilyva\AppData\Local\Plex Media Server\Plug-ins\Kinopoisk.bundle\Contents\Libraries\Shared\kinoplex\utils.py", line 228, in update_event
    self.fire('update', metadict, media, lang, force, periodic)
  File "C:\Users\ilyva\AppData\Local\Plex Media Server\Plug-ins\Kinopoisk.bundle\Contents\Libraries\Shared\kinoplex\agent.py", line 15, in fire
    [getattr(s, event)(*args, **kwargs) for s in self.sources]
  File "C:\Users\ilyva\AppData\Local\Plex Media Server\Plug-ins\Kinopoisk.bundle\Contents\Libraries\Shared\kinoplex\sources\kinopoisk.py", line 250, in update
    self.load_meta(metadata)
  File "C:\Users\ilyva\AppData\Local\Plex Media Server\Plug-ins\Kinopoisk.bundle\Contents\Libraries\Shared\kinoplex\sources\kinopoisk.py", line 330, in load_meta
    metadata['summary'] = summary_add + movie_data.get('description', '')
TypeError: cannot concatenate 'str' and 'NoneType' objects
```