### PR TITLE
Fix TVDB source problem with updating episodes data for series

### DIFF
--- a/Contents/Libraries/Shared/kinoplex/sources/tvdb.py
+++ b/Contents/Libraries/Shared/kinoplex/sources/tvdb.py
@@ -47,19 +47,19 @@ class TVDBSource(SourceBase):
         if source_id:
             series_resp = self.make_request(self.conf.series, lang, source_id)
             
-        if 'errors' in series_resp and series_resp['errors'].get('invalidLanguage') and lang != 'en':
-            series_resp = self.make_request(self.conf.series, 'en', source_id)
+            if 'errors' in series_resp and series_resp['errors'].get('invalidLanguage') and lang != 'en':
+                series_resp = self.make_request(self.conf.series, 'en', source_id)
 
-        series_data = series_resp.get('data', {})
-        if not series_data:
-            self.l('no data for tv serie %s' % source_id)
-            return
+            series_data = series_resp.get('data', {})
+            if not series_data:
+                self.l('no data for tv serie %s' % source_id)
+                return
 
-        episodes_data = []
-        next_page = 1
-        while isinstance(next_page, int) or (isinstance(next_page, basestring) and next_page.isdigit()):
-            next_page = int(next_page)
-            episode_data_page = self.make_request(self.conf.episodes, lang, source_id, next_page)
-            episodes_data.extend(episode_data_page['data'])
-            next_page = episode_data_page['links']['next']
+            episodes_data = []
+            next_page = 1
+            while isinstance(next_page, int) or (isinstance(next_page, basestring) and next_page.isdigit()):
+                next_page = int(next_page)
+                episode_data_page = self.make_request(self.conf.episodes, lang, source_id, next_page)
+                episodes_data.extend(episode_data_page['data'])
+                next_page = episode_data_page['links']['next']
                 


### PR DESCRIPTION
Problem caused exception, which led to problems described in https://github.com/Jenstel/Kinopoisk.bundle/issues/27

```
2024-01-05 01:47:22,193 (7fe13e656b38) :  INFO (mm:9) - update from MovieManiaSource
2024-01-05 01:47:22,193 (7fe13e656b38) :  INFO (tvdb:43) - update from TVDBSource
2024-01-05 01:47:22,194 (7fe13e656b38) :  DEBUG (utils:111) - Requesting 'https://api.thetvdb.com/login'
2024-01-05 01:47:22,665 (7fe13e656b38) :  DEBUG (utils:111) - Requesting 'https://api.thetvdb.com/series/None/episodes?page=1'
2024-01-05 01:47:22,861 (7fe13e656b38) :  ERROR (utils:232) - 'data'
Traceback (most recent call last):
  File "/var/packages/PlexMediaServer/shares/PlexMediaServer/AppData/Plex Media Server/Plug-ins/Kinopoisk.bundle/Contents/Libraries/Shared/kinoplex/utils.py", line 228, in update_event
    self.fire('update', metadict, media, lang, force, periodic)
  File "/var/packages/PlexMediaServer/shares/PlexMediaServer/AppData/Plex Media Server/Plug-ins/Kinopoisk.bundle/Contents/Libraries/Shared/kinoplex/agent.py", line 15, in fire
    [getattr(s, event)(*args, **kwargs) for s in self.sources]
  File "/var/packages/PlexMediaServer/shares/PlexMediaServer/AppData/Plex Media Server/Plug-ins/Kinopoisk.bundle/Contents/Libraries/Shared/kinoplex/sources/tvdb.py", line 63, in update
    episodes_data.extend(episode_data_page['data'])
KeyError: 'data'
```

Along with https://github.com/Jenstel/Kinopoisk.bundle/pull/28 fixed issue #27 